### PR TITLE
workflow.py.in: Use correct Image import.

### DIFF
--- a/src/software/SfM/workflow.py.in
+++ b/src/software/SfM/workflow.py.in
@@ -8,7 +8,7 @@ import os
 import subprocess
 import sys
 import re
-import Image
+from PIL import Image
 
 # Initialize vars
 total_output = "Workflow finished.";


### PR DESCRIPTION
Fixes 'ImportError: No module named 'Image'.